### PR TITLE
remove delegationtoken parameter

### DIFF
--- a/sql/service/src/main/java/org/apache/spark/sql/service/cli/CLIService.java
+++ b/sql/service/src/main/java/org/apache/spark/sql/service/cli/CLIService.java
@@ -132,21 +132,21 @@ public class CLIService extends CompositeService implements ICLIService {
       Map<String, String> configuration) throws ServiceSQLException {
     SessionHandle sessionHandle =
         sessionManager.openSession(protocol, username, password, null,
-            configuration, false, null);
+            configuration, false);
     LOG.debug(sessionHandle + ": openSession()");
     return sessionHandle;
   }
 
   /**
    * @deprecated  Use {@link #openSessionWithImpersonation(TProtocolVersion, String,
-   *                              String, String, Map, String)}
+   *                              String, String, Map)}
    */
   @Deprecated
   public SessionHandle openSessionWithImpersonation(TProtocolVersion protocol, String username,
-      String password, Map<String, String> configuration, String delegationToken)
+      String password, Map<String, String> configuration)
           throws ServiceSQLException {
     SessionHandle sessionHandle = sessionManager.openSession(protocol, username, password,
-        null, configuration, true, delegationToken);
+        null, configuration, true);
     LOG.debug(sessionHandle + ": openSessionWithImpersonation()");
     return sessionHandle;
   }
@@ -154,16 +154,16 @@ public class CLIService extends CompositeService implements ICLIService {
   public SessionHandle openSession(TProtocolVersion protocol, String username, String password,
       String ipAddress, Map<String, String> configuration) throws ServiceSQLException {
     SessionHandle sessionHandle = sessionManager.openSession(protocol, username, password,
-        ipAddress, configuration, false, null);
+        ipAddress, configuration, false);
     LOG.debug(sessionHandle + ": openSession()");
     return sessionHandle;
   }
 
   public SessionHandle openSessionWithImpersonation(TProtocolVersion protocol, String username,
-      String password, String ipAddress, Map<String, String> configuration, String delegationToken)
+      String password, String ipAddress, Map<String, String> configuration)
           throws ServiceSQLException {
     SessionHandle sessionHandle = sessionManager.openSession(protocol, username, password,
-        ipAddress, configuration, true, delegationToken);
+        ipAddress, configuration, true);
     LOG.debug(sessionHandle + ": openSession()");
     return sessionHandle;
   }
@@ -175,7 +175,7 @@ public class CLIService extends CompositeService implements ICLIService {
   public SessionHandle openSession(String username, String password,
       Map<String, String> configuration) throws ServiceSQLException {
     SessionHandle sessionHandle = sessionManager.openSession(SERVER_VERSION, username, password,
-        null, configuration, false, null);
+        null, configuration, false);
     LOG.debug(sessionHandle + ": openSession()");
     return sessionHandle;
   }
@@ -185,9 +185,9 @@ public class CLIService extends CompositeService implements ICLIService {
    */
   @Override
   public SessionHandle openSessionWithImpersonation(String username, String password,
-      Map<String, String> configuration, String delegationToken) throws ServiceSQLException {
+      Map<String, String> configuration) throws ServiceSQLException {
     SessionHandle sessionHandle = sessionManager.openSession(SERVER_VERSION, username, password,
-        null, configuration, true, delegationToken);
+        null, configuration, true);
     LOG.debug(sessionHandle + ": openSession()");
     return sessionHandle;
   }

--- a/sql/service/src/main/java/org/apache/spark/sql/service/cli/ICLIService.java
+++ b/sql/service/src/main/java/org/apache/spark/sql/service/cli/ICLIService.java
@@ -29,7 +29,7 @@ public interface ICLIService {
           throws ServiceSQLException;
 
   SessionHandle openSessionWithImpersonation(String username, String password,
-      Map<String, String> configuration, String delegationToken)
+      Map<String, String> configuration)
           throws ServiceSQLException;
 
   void closeSession(SessionHandle sessionHandle)

--- a/sql/service/src/main/java/org/apache/spark/sql/service/cli/session/ServiceSessionBase.java
+++ b/sql/service/src/main/java/org/apache/spark/sql/service/cli/session/ServiceSessionBase.java
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.service.cli.session;
 
 import java.io.File;
+import java.util.List;
 
 import org.apache.spark.sql.SQLContext;
 import org.apache.spark.sql.internal.SQLConf;
@@ -86,4 +87,8 @@ public interface ServiceSessionBase {
   void setIpAddress(String ipAddress);
 
   long getLastAccessTime();
+
+  Boolean isImpersonation();
+
+  List<String> getImpersonationTokens();
 }

--- a/sql/service/src/main/java/org/apache/spark/sql/service/cli/session/ServiceSessionImpl.java
+++ b/sql/service/src/main/java/org/apache/spark/sql/service/cli/session/ServiceSessionImpl.java
@@ -549,6 +549,16 @@ public class ServiceSessionImpl implements ServiceSession {
   }
 
   @Override
+  public Boolean isImpersonation() {
+    return false;
+  }
+
+  @Override
+  public List<String> getImpersonationTokens() {
+    return null;
+  }
+
+  @Override
   public void closeExpiredOperations() {
     OperationHandle[] handles = opHandleSet.toArray(new OperationHandle[opHandleSet.size()]);
     if (handles.length > 0) {

--- a/sql/service/src/main/java/org/apache/spark/sql/service/cli/session/ServiceSessionImplwithUGI.java
+++ b/sql/service/src/main/java/org/apache/spark/sql/service/cli/session/ServiceSessionImplwithUGI.java
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.service.cli.session;
 
 import java.io.IOException;
+import java.util.List;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -37,12 +38,12 @@ import org.apache.spark.sql.service.rpc.thrift.TProtocolVersion;
 public class ServiceSessionImplwithUGI extends ServiceSessionImpl {
 
   private UserGroupInformation sessionUgi = null;
-  private String delegationTokenStr = null;
+  private List<String> delegationTokens = null;
   private ServiceSession proxySession = null;
   static final Logger LOG = LoggerFactory.getLogger(ServiceSessionImplwithUGI.class);
 
   public ServiceSessionImplwithUGI(TProtocolVersion protocol, String username, String password,
-                                   SQLContext sqlContext, String ipAddress, String delegationToken)
+                                   SQLContext sqlContext, String ipAddress)
       throws ServiceSQLException {
     super(protocol, username, password, sqlContext, ipAddress);
     setSessionUGI(username);
@@ -69,8 +70,18 @@ public class ServiceSessionImplwithUGI extends ServiceSessionImpl {
     return this.sessionUgi;
   }
 
-  public String getDelegationToken() {
-    return this.delegationTokenStr;
+  @Override
+  public Boolean isImpersonation() {
+    return true;
+  }
+
+  public void setImpersonationTokens(List<String> token) {
+    this.delegationTokens = token;
+  }
+
+  @Override
+  public List<String> getImpersonationTokens() {
+    return this.delegationTokens;
   }
 
   @Override

--- a/sql/service/src/main/java/org/apache/spark/sql/service/cli/session/SessionManager.java
+++ b/sql/service/src/main/java/org/apache/spark/sql/service/cli/session/SessionManager.java
@@ -214,7 +214,7 @@ public class SessionManager extends CompositeService {
 
   public SessionHandle openSession(TProtocolVersion protocol, String username, String password,
       String ipAddress, Map<String, String> sessionConf) throws ServiceSQLException {
-    return openSession(protocol, username, password, ipAddress, sessionConf, false, null);
+    return openSession(protocol, username, password, ipAddress, sessionConf, false);
   }
 
   /**
@@ -232,13 +232,12 @@ public class SessionManager extends CompositeService {
    * @param ipAddress
    * @param sessionConf
    * @param withImpersonation
-   * @param delegationToken
    * @return
    * @throws ServiceSQLException
    */
   public SessionHandle openSession(TProtocolVersion protocol, String username, String password,
-      String ipAddress, Map<String, String> sessionConf, boolean withImpersonation,
-      String delegationToken) throws ServiceSQLException {
+      String ipAddress, Map<String, String> sessionConf, boolean withImpersonation)
+      throws ServiceSQLException {
     ServiceSession session;
     SQLContext ctx = null;
     if(sqlContext.conf().hiveThriftServerSingleSession()) {
@@ -251,7 +250,7 @@ public class SessionManager extends CompositeService {
     // Within the proxy object, we wrap the method call in a UserGroupInformation#doAs
     if (withImpersonation) {
       ServiceSessionImplwithUGI sessionWithUGI = new ServiceSessionImplwithUGI(protocol, username,
-          password, ctx, ipAddress, delegationToken);
+          password, ctx, ipAddress);
       session = ServiceSessionProxy.getProxy(sessionWithUGI, sessionWithUGI.getSessionUgi());
       sessionWithUGI.setProxySession(session);
     } else {

--- a/sql/service/src/main/java/org/apache/spark/sql/service/cli/thrift/ThriftCLIService.java
+++ b/sql/service/src/main/java/org/apache/spark/sql/service/cli/thrift/ThriftCLIService.java
@@ -398,9 +398,8 @@ public abstract class ThriftCLIService extends AbstractService
     SessionHandle sessionHandle;
     if (((boolean) cliService.getSqlConf().getConf(ServiceConf.THRIFTSERVER_ENABLE_DOAS())) &&
         (userName != null)) {
-      String delegationTokenStr = "";
       sessionHandle = cliService.openSessionWithImpersonation(protocol, userName,
-          req.getPassword(), ipAddress, req.getConfiguration(), delegationTokenStr);
+          req.getPassword(), ipAddress, req.getConfiguration());
     } else {
       sessionHandle = cliService.openSession(protocol, userName, req.getPassword(),
           ipAddress, req.getConfiguration());

--- a/sql/service/src/main/java/org/apache/spark/sql/service/cli/thrift/ThriftCLIServiceClient.java
+++ b/sql/service/src/main/java/org/apache/spark/sql/service/cli/thrift/ThriftCLIServiceClient.java
@@ -70,7 +70,7 @@ public class ThriftCLIServiceClient extends CLIServiceClient {
    */
   @Override
   public SessionHandle openSessionWithImpersonation(String username, String password,
-      Map<String, String> configuration, String delegationToken) throws ServiceSQLException {
+      Map<String, String> configuration) throws ServiceSQLException {
     throw new ServiceSQLException("open with impersonation operation " +
         "is not supported in the client");
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

it is used for build each session's Hive object, no need now and we will have new way to proxy hive auth