### PR TITLE
Use origin ConfigBuilder instead of SQLConf.buildConf()

### DIFF
--- a/sql/service/src/main/java/org/apache/spark/sql/service/auth/CustomAuthenticationProviderImpl.java
+++ b/sql/service/src/main/java/org/apache/spark/sql/service/auth/CustomAuthenticationProviderImpl.java
@@ -41,7 +41,7 @@ public class CustomAuthenticationProviderImpl implements PasswdAuthenticationPro
   CustomAuthenticationProviderImpl(SparkConf sparkConf) {
     Configuration conf = SparkHadoopUtil.get().newConfiguration(sparkConf);
     conf.set(ServiceConf.THRIFTSERVER_CUSTOM_AUTHENTICATION_CLASS().key(),
-            SQLConf.get().getConf(ServiceConf.THRIFTSERVER_CUSTOM_AUTHENTICATION_CLASS()));
+            sparkConf.get(ServiceConf.THRIFTSERVER_CUSTOM_AUTHENTICATION_CLASS()));
     Class<? extends PasswdAuthenticationProvider> customHandlerClass =
       (Class<? extends PasswdAuthenticationProvider>) conf.getClass(
         ServiceConf.THRIFTSERVER_CUSTOM_AUTHENTICATION_CLASS().key(),


### PR DESCRIPTION
### What changes were proposed in this pull request?

Service conf change to SparkConf, here we should not use SQLConf.buildConf()